### PR TITLE
🛠️ [FIX] #52: 개최자만 티켓 번호로 조회 가능

### DIFF
--- a/src/main/java/com/example/demo/domain/ticket/service/TicketService.java
+++ b/src/main/java/com/example/demo/domain/ticket/service/TicketService.java
@@ -112,7 +112,9 @@ public class TicketService {
 
         User user = userService.getCurrentUser();
 
-        validateUser(ticket, user);
+        if (!(ticket.getUser().equals(user)) && !(ticket.getSession().getEvent().getOrganizer().equals(user)))
+            throw new CustomException(ErrorStatus.TICKEt_INVALID_USER);
+
         return ticketConverter.toTicketDTO(ticket);
     }
 
@@ -125,7 +127,9 @@ public class TicketService {
 
         User user = userService.getCurrentUser();
 
-        validateUser(ticket, user);
+        if (!(ticket.getSession().getEvent().getOrganizer().equals(user)))
+            throw new CustomException(ErrorStatus.TICKEt_INVALID_USER);
+
         return ticketConverter.toTicketDTO(ticket);
     }
 
@@ -156,8 +160,4 @@ public class TicketService {
         }
     }
 
-    private void validateUser(Ticket ticket, User user) {
-        if (!(ticket.getUser().equals(user)) && !(ticket.getSession().getEvent().getOrganizer().equals(user)))
-            throw new CustomException(ErrorStatus.TICKEt_INVALID_USER);
-    }
 }


### PR DESCRIPTION
## #⃣ 연관된 이슈

#52 

## 📝 작업 내용

개최자만 티켓 번호로 조회 가능
티켓 아이디 조회는 개최자 및 소유자만

### 📸 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
